### PR TITLE
Fix typo in error name

### DIFF
--- a/lib/u2f/errors.rb
+++ b/lib/u2f/errors.rb
@@ -8,7 +8,7 @@ module U2F
   class AttestationSignatureError < Error; end
   class NoMatchingRequestError < Error; end
   class NoMatchingRegistrationError < Error; end
-  class CounterToLowError < Error; end
+  class CounterTooLowError < Error; end
   class AuthenticationFailedError < Error; end
   class UserNotPresentError < Error;end
 

--- a/lib/u2f/u2f.rb
+++ b/lib/u2f/u2f.rb
@@ -39,7 +39,7 @@ module U2F
     #   - +ClientDataTypeError+:: if the response is of the wrong type
     #   - +AuthenticationFailedError+:: if the authentication failed
     #   - +UserNotPresentError+:: if the user wasn't present during the authentication
-    #   - +CounterToLowError+:: if there is a counter mismatch between the registered one and the one in the response.
+    #   - +CounterTooLowError+:: if there is a counter mismatch between the registered one and the one in the response.
     #
     def authenticate!(challenges, response, registration_public_key,
                       registration_counter)
@@ -60,7 +60,7 @@ module U2F
       fail UserNotPresentError unless response.user_present?
 
       unless response.counter > registration_counter
-        fail CounterToLowError
+        fail CounterTooLowError
       end
     end
 

--- a/spec/lib/u2f_spec.rb
+++ b/spec/lib/u2f_spec.rb
@@ -61,8 +61,8 @@ describe U2F do
 
     context 'with incorrect counter' do
       let(:counter) { 1000 }
-      it 'raises CounterToLowError' do
-        expect { u2f_authenticate }.to raise_error(U2F::CounterToLowError)
+      it 'raises CounterTooLowError' do
+        expect { u2f_authenticate }.to raise_error(U2F::CounterTooLowError)
       end
     end
     context 'with incorrect counter' do


### PR DESCRIPTION
The error name should be `CounterTooLowError`.

While this does introduce some minor backwards incompatibility, best to take care of it now while the library is still very young.