### PR TITLE
Fix tests in some environments

### DIFF
--- a/lib/u2f.rb
+++ b/lib/u2f.rb
@@ -1,6 +1,7 @@
 require 'base64'
 require 'json'
 require 'openssl'
+require 'securerandom'
 
 require 'u2f/client_data'
 require 'u2f/errors'


### PR DESCRIPTION
My environment doesn't have `securerandom` loaded by default, and needs an explicit `require 'securerandom'` for the tests to pass. I was getting this:

```
$ rake
/home/eric/.rbenv/versions/2.2.0/bin/ruby -I/home/eric/.rbenv/versions/2.2.0/lib/ruby/gems/2.2.0/gems/rspec-support-3.1.2/lib:/home/eric/.rbenv/versions/2.2.0/lib/ruby/gems/2.2.0/gems/rspec-core-3.1.7/lib /home/eric/.rbenv/versions/2.2.0/lib/ruby/gems/2.2.0/gems/rspec-core-3.1.7/exe/rspec --pattern spec/\*\*\{,/\*/\*\*\}/\*_spec.rb
................F....F.....

Failures:

  1) U2F#authentication_requests returns an array of requests
     Failure/Error: let(:requests) { u2f.authentication_requests(key_handle) }
     NameError:
       uninitialized constant SecureRandom
     # ./lib/u2f/u2f.rb:75:in `challenge'
     # ./lib/u2f/u2f.rb:24:in `block in authentication_requests'
     # ./lib/u2f/u2f.rb:23:in `map'
     # ./lib/u2f/u2f.rb:23:in `authentication_requests'
     # ./spec/lib/u2f_spec.rb:36:in `block (3 levels) in <top (required)>'
     # ./spec/lib/u2f_spec.rb:38:in `block (3 levels) in <top (required)>'

  2) U2F#registration_requests returns an array of requests
     Failure/Error: let(:requests) { u2f.registration_requests }
     NameError:
       uninitialized constant SecureRandom
     # ./lib/u2f/u2f.rb:75:in `challenge'
     # ./lib/u2f/u2f.rb:86:in `registration_requests'
     # ./spec/lib/u2f_spec.rb:77:in `block (3 levels) in <top (required)>'
     # ./spec/lib/u2f_spec.rb:79:in `block (3 levels) in <top (required)>'

Finished in 0.01373 seconds (files took 0.346 seconds to load)
27 examples, 2 failures

Failed examples:

rspec ./spec/lib/u2f_spec.rb:37 # U2F#authentication_requests returns an array of requests
rspec ./spec/lib/u2f_spec.rb:78 # U2F#registration_requests returns an array of requests
Coverage report generated for RSpec to /home/eric/konklone/ruby-u2f/coverage. 192 / 192 LOC (100.0%) covered.
[Coveralls] Outside the Travis environment, not sending data.
/home/eric/.rbenv/versions/2.2.0/bin/ruby -I/home/eric/.rbenv/versions/2.2.0/lib/ruby/gems/2.2.0/gems/rspec-support-3.1.2/lib:/home/eric/.rbenv/versions/2.2.0/lib/ruby/gems/2.2.0/gems/rspec-core-3.1.7/lib /home/eric/.rbenv/versions/2.2.0/lib/ruby/gems/2.2.0/gems/rspec-core-3.1.7/exe/rspec --pattern spec/\*\*\{,/\*/\*\*\}/\*_spec.rb failed
```

This test explicitly requires the Ruby stdlib's `securerandom` library, which fixes the tests for me. It's not clear to me why Travis doesn't need this -- maybe because it [uses SecureRandom itself](https://github.com/travis-ci/travis-support/blob/master/lib/core_ext/securerandom.rb). 